### PR TITLE
Updating for API-breaking changes introduced in Spark 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<scala.version>2.10.4</scala.version>
 		<scala.binary.version>2.10</scala.binary.version>
 		<scalatest.version>2.2.1</scalatest.version>
-		<spark.version>1.6.1</spark.version>
+		<spark.version>2.1.0</spark.version>
 	</properties>
 
 	<repositories>

--- a/src/main/scala/org/apache/spark/mllib/clustering/dbscan/DBSCAN.scala
+++ b/src/main/scala/org/apache/spark/mllib/clustering/dbscan/DBSCAN.scala
@@ -16,8 +16,8 @@
  */
 package org.apache.spark.mllib.clustering.dbscan
 
-import org.apache.spark.Logging
-import org.apache.spark.SparkContext.rddToPairRDDFunctions
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.PairRDDFunctions
 import org.apache.spark.mllib.clustering.dbscan.DBSCANLabeledPoint.Flag
 import org.apache.spark.mllib.linalg.Vector
 import org.apache.spark.rdd.RDD

--- a/src/main/scala/org/apache/spark/mllib/clustering/dbscan/EvenSplitPartitioner.scala
+++ b/src/main/scala/org/apache/spark/mllib/clustering/dbscan/EvenSplitPartitioner.scala
@@ -18,7 +18,7 @@ package org.apache.spark.mllib.clustering.dbscan
 
 import scala.annotation.tailrec
 
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 
 /**
  * Helper methods for calling the partitioner

--- a/src/main/scala/org/apache/spark/mllib/clustering/dbscan/LocalDBSCANArchery.scala
+++ b/src/main/scala/org/apache/spark/mllib/clustering/dbscan/LocalDBSCANArchery.scala
@@ -18,7 +18,7 @@ package org.apache.spark.mllib.clustering.dbscan
 
 import scala.collection.mutable.Queue
 
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import org.apache.spark.mllib.clustering.dbscan.DBSCANLabeledPoint.Flag
 
 import archery.Box

--- a/src/main/scala/org/apache/spark/mllib/clustering/dbscan/LocalDBSCANNaive.scala
+++ b/src/main/scala/org/apache/spark/mllib/clustering/dbscan/LocalDBSCANNaive.scala
@@ -18,7 +18,7 @@ package org.apache.spark.mllib.clustering.dbscan
 
 import scala.collection.mutable.Queue
 
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import org.apache.spark.mllib.clustering.dbscan.DBSCANLabeledPoint.Flag
 import org.apache.spark.mllib.linalg.Vectors
 

--- a/src/test/scala/org/apache/spark/mllib/clustering/dbscan/DBSCANSuite.scala
+++ b/src/test/scala/org/apache/spark/mllib/clustering/dbscan/DBSCANSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.mllib.clustering.dbscan
 
-import org.apache.spark.SparkContext.rddToPairRDDFunctions
+import org.apache.spark.rdd.PairRDDFunctions
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.scalatest.Matchers


### PR DESCRIPTION
Summary of changes: 

- Logging moved under org.apache.spark.internal
- PairRDDFunctions moved under org.apache.spark.rdd